### PR TITLE
fix no method error when foreign key is not default actable_id

### DIFF
--- a/lib/active_record/acts_as/instance_methods.rb
+++ b/lib/active_record/acts_as/instance_methods.rb
@@ -10,10 +10,14 @@ module ActiveRecord
         super || acting_as?(klass)
       end
 
+      def acting_as_foreign_key
+        acting_as[acting_as_reflection.foreign_key]
+      end
+
       # Is the superclass persisted to the database?
       def acting_as_persisted?
         return false if acting_as.nil?
-        !acting_as.id.nil? && !acting_as.actable_id.nil?
+        !acting_as.id.nil? && !acting_as_foreign_key.nil?
       end
 
       def actable_must_be_valid

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -82,6 +82,17 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
     end
   end
 
+  describe "#acting_as_foreign_key" do
+    let(:product_foreign_key_value) do
+      pen.acting_as[pen.acting_as.actable_reflection.foreign_key]
+    end
+    it "return acts_as foreign key value" do
+      pen.save
+      expect(pen.acting_as_foreign_key).to eq(product_foreign_key_value)
+      expect(pen.acting_as_foreign_key).to eq(pen.id)
+    end
+  end
+
   describe "#acting_as=" do
     it "sets acts_as model" do
       product = Product.new(name: 'new product', price: 0.99)


### PR DESCRIPTION
When the `acting_as` model uses a different relationship name other than the default actable, lib/active_record/acts_as/instance_methods.rb:16 will throw an no method error.

The solution is pick the right foreign key name from the reflection, instead of always use the default key name.