### PR TITLE
Add support for ActiveRecord::Store

### DIFF
--- a/lib/active_record/acts_as/instance_methods.rb
+++ b/lib/active_record/acts_as/instance_methods.rb
@@ -46,7 +46,23 @@ module ActiveRecord
           acting_as.send(:write_attribute, attr_name, value, *args, &block)
         end
       end
-      private :write_attribute
+
+      def read_store_attribute(store_attribute, key)
+        if attribute_method?(store_attribute.to_s)
+          super
+        else
+          acting_as.read_store_attribute(store_attribute, key)
+        end
+      end
+
+      def write_store_attribute(store_attribute, key, value)
+        if attribute_method?(store_attribute.to_s)
+          super
+        else
+          acting_as.send(:write_store_attribute, store_attribute, key, value)
+        end
+      end
+      private :write_attribute, :write_store_attribute
 
       def attributes
         acting_as_persisted? ? acting_as.attributes.except(acting_as_reflection.type, acting_as_reflection.foreign_key).merge(super) : super

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -123,6 +123,33 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
       expect(pen.present).to eq("pen - $0.8")
     end
 
+    it 'responds to serialized attribute' do
+      expect(pen).to respond_to('option1')
+      expect(isolated_pen).to respond_to('option2')
+    end
+
+    it 'responds to supermodel serialized attribute' do
+      expect(pen).to respond_to('global_option')
+      expect(isolated_pen).to respond_to('global_option')
+    end
+
+    it 'does not respond to other models serialized attribute' do
+      expect(pen).to_not respond_to('option2')
+      expect(isolated_pen).to_not respond_to('option1')
+    end
+
+    it 'saves supermodel serialized attribute on save' do
+      pen.option1 = 'value1'
+      pen.global_option = 'globalvalue'
+      pen.save
+      pen.reload
+      isolated_pen.save
+      isolated_pen.reload
+      expect(pen.option1).to eq('value1')
+      expect(isolated_pen).to_not respond_to('option1')
+      expect(JSON.parse(pen.to_json)).to eq(JSON.parse('{"id":' + pen.id.to_s + ',"name":"pen","price":0.8,"store_id":null,"settings":{"global_option":"globalvalue","option1":"value1"},"color":"red"}'))
+    end
+
     it "saves supermodel attributes on save" do
       pen.save
       pen.reload
@@ -185,7 +212,7 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
       it "if the submodel instance association exists" do
         p = Product.new(name: 'Test Pen', price: 0.8, actable: pen)
         p.save
-        expect(JSON.parse(pen.to_json)).to eq(JSON.parse('{"id":' + pen.id.to_s + ',"name":"pen","price":0.8,"store_id":null,"color":"red"}'))
+        expect(JSON.parse(pen.to_json)).to eq(JSON.parse('{"id":' + pen.id.to_s + ',"name":"pen","price":0.8,"store_id":null,"settings": {},"color":"red"}'))
       end
     end
 

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -5,6 +5,7 @@ class Product < ActiveRecord::Base
   actable
   belongs_to :store
   validates_presence_of :name, :price
+  store :settings, accessors: [:global_option]
 
   def present
     "#{name} - $#{price}"
@@ -17,6 +18,7 @@ end
 
 class Pen < ActiveRecord::Base
   acts_as :product
+  store_accessor :settings, :option1
 
   validates_presence_of :color
 end
@@ -24,6 +26,7 @@ end
 class IsolatedPen < ActiveRecord::Base
   self.table_name = :pens
   acts_as :product, validates_actable: false
+  store_accessor :settings, :option2
 
   validates_presence_of :color
 end
@@ -60,6 +63,7 @@ initialize_database do
     t.string :name
     t.float :price
     t.integer :store_id
+    t.text :settings
     t.actable
   end
 


### PR DESCRIPTION
Rails 4.1+ changed the way that the ActiveRecord::Store reads and writes values to use @column_types in order to cast the value to the correct type (https://github.com/rails/rails/commit/0492ea6d39e48c5bdb1d15eb4afdd54b00ece091). The issue is that @column_types will look for the store column on the class you define the store_accessor instead of where the store is defined. This causes issues if you have a MTI where the supermodel table has the store column (settings in the rspec tests), but you want the specific models to each have different accessors. 

In the tests you can see that the supermodel Product has an accessor "global_option" which every child class should be able to access like regular attributes. Pen then has it's own accessor for "option1" which it should be the only class to respond to (IsolatedPen should not be able to get nor set option1 as it doesn't know it exists), and IsolatedPen should have it's own accessor for "option2" which Pen cannot get/set.

As for the actual fix, I just mimicked the way that you're already reading and writing regular attributes