### PR TITLE
Implement support for `Model#has_attribute?`, `Model#column_for_attribute`, and `Model._reflections`.

### DIFF
--- a/lib/active_record/acts_as.rb
+++ b/lib/active_record/acts_as.rb
@@ -3,6 +3,7 @@ require 'active_record'
 require 'active_record/acts_as/version'
 require 'active_record/acts_as/relation'
 require 'active_record/acts_as/migration'
+require 'active_record/acts_as/class_methods'
 require 'active_record/acts_as/instance_methods'
 require 'active_record/acts_as/querying'
 

--- a/lib/active_record/acts_as/class_methods.rb
+++ b/lib/active_record/acts_as/class_methods.rb
@@ -1,0 +1,14 @@
+module ActiveRecord
+  module ActsAs
+    module ClassMethods
+      def self.included(module_)
+        module_.alias_method_chain :_reflections, :acts_as
+      end
+
+      def _reflections_with_acts_as
+        @_reflections_acts_as_cache ||=
+          _reflections_without_acts_as.reverse_merge(acting_as_model._reflections)
+      end
+    end
+  end
+end

--- a/lib/active_record/acts_as/instance_methods.rb
+++ b/lib/active_record/acts_as/instance_methods.rb
@@ -72,6 +72,22 @@ module ActiveRecord
         acting_as_persisted? ? super | (acting_as.attribute_names - [acting_as_reflection.type, acting_as_reflection.foreign_key]) : super
       end
 
+      def has_attribute?(attr_name, as_original_class = false)
+        if as_original_class
+          super(attr_name)
+        else
+          super(attr_name) || acting_as.has_attribute?(attr_name)
+        end
+      end
+
+      def column_for_attribute(name)
+        if has_attribute?(name, true)
+          super(name)
+        else
+          acting_as.column_for_attribute(name)
+        end
+      end
+
 
       def respond_to?(name, include_private = false, as_original_class = false)
         as_original_class ? super(name, include_private) : super(name, include_private) || acting_as.respond_to?(name)

--- a/lib/active_record/acts_as/relation.rb
+++ b/lib/active_record/acts_as/relation.rb
@@ -22,6 +22,9 @@ module ActiveRecord
           alias_method :acting_as=, "#{name}=".to_sym
 
           include ActsAs::InstanceMethods
+          singleton_class.module_eval do
+            include ActsAs::ClassMethods
+          end
         end
 
         def acting_as?(other = nil)

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -111,6 +111,40 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
     end
   end
 
+  describe "#has_attribute?" do
+    context "when the attribute is defined on the superclass" do
+      it "queries the superclass" do
+        expect(pen.has_attribute?(:name)).to be_truthy
+      end
+    end
+
+    context "when the attribute is defined on the subclass" do
+      it "queries the subclass" do
+        expect(pen.has_attribute?(:color)).to be_truthy
+      end
+    end
+  end
+
+  describe "#column_for_attribute" do
+    context "when the attribute is defined on the superclass" do
+      it "queries the superclass" do
+        expect(pen.column_for_attribute(:name)).to eq(pen.product.column_for_attribute(:name))
+      end
+    end
+
+    context "when the attribute is defined on the subclass" do
+      it "queries the subclass" do
+        expect(pen.column_for_attribute(:color)).not_to be_nil
+      end
+    end
+  end
+
+  describe "._reflections" do
+    it "merges the reflections on both superclass and subclass" do
+      expect(Pen._reflections.length).to eq(Product._reflections.length + 1)
+    end
+  end
+
   it "have supermodel attributes accessible on creation" do
     expect{Pen.create(pen_attributes)}.to_not raise_error
   end


### PR DESCRIPTION
These are needed to perform reflection, as some gems (e.g. Simple Form) does to determine the correct field type to display.

Fixes Coursemology/Coursemology2#349