### PR TITLE
Union the validators defined on the superclass and subclass.

### DIFF
--- a/lib/active_record/acts_as/class_methods.rb
+++ b/lib/active_record/acts_as/class_methods.rb
@@ -9,6 +9,10 @@ module ActiveRecord
         @_reflections_acts_as_cache ||=
           _reflections_without_acts_as.reverse_merge(acting_as_model._reflections)
       end
+
+      def validators_on(*args)
+        super + acting_as_model.validators_on(*args)
+      end
     end
   end
 end

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -139,6 +139,13 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
     end
   end
 
+  describe ".validators_on" do
+    it "merges the validations on both superclass and subclass" do
+      expect(Pen.validators_on(:name, :price)).to contain_exactly(
+        *Product.validators_on(:name, :price))
+    end
+  end
+
   describe "._reflections" do
     it "merges the reflections on both superclass and subclass" do
       expect(Pen._reflections.length).to eq(Product._reflections.length + 1)


### PR DESCRIPTION
This overrides validators_on to check the superclass for validators defined on the fields specified. This helps Simple Form in determining field properties, e.g. the required attribute and display the appropriate UI.