### PR TITLE
Fix remove_actable migration helper

### DIFF
--- a/lib/active_record/acts_as/migration.rb
+++ b/lib/active_record/acts_as/migration.rb
@@ -16,7 +16,7 @@ module ActiveRecord
         def remove_actable(options = {})
           name = options.delete(:as) || :actable
           options[:polymorphic] = true
-          @base.remove_reference(@table_name, name, options)
+          @base.remove_reference(@name, name, options)
         end
       end
     end

--- a/spec/migrations_spec.rb
+++ b/spec/migrations_spec.rb
@@ -5,21 +5,76 @@ require 'active_record/acts_as'
 class Product < ActiveRecord::Base
 end
 
+class RemoveActableFromProducts < ActiveRecord::Migration
+  def change
+    change_table(:products) do |t|
+      t.remove_actable
+    end
+  end
+end
+
+class RemoveProduceableFromProducts < ActiveRecord::Migration
+  def change
+    change_table(:products) do |t|
+      t.remove_actable(as: :produceable)
+    end
+  end
+end
 
 RSpec.describe ".actable" do
   context "in .create_table block" do
     after { initialize_schema }
     context "with :as options" do
-      it "creates plymorphic reference columns with given name" do
+      it "creates polymorphic reference columns with given name" do
         initialize_database { create_table(:products) { |t| t.actable(as: :produceable) } }
         expect(Product.column_names).to include('produceable_id', 'produceable_type')
       end
     end
 
     context "with no args" do
-      it "creates plymorphic reference columns" do
+      it "creates polymorphic reference columns" do
         initialize_database { create_table(:products) { |t| t.actable } }
         expect(Product.column_names).to include('actable_id', 'actable_type')
+      end
+    end
+  end
+end
+
+RSpec.describe ".remove_actable" do
+  context "in .modify_table block" do
+    after { initialize_schema }
+
+    context "with :as options" do
+      before do
+        initialize_database do
+          create_table(:products) do |t|
+            t.string :name
+            t.actable(as: :produceable)
+          end
+        end
+      end
+      it "removes polymorphic reference columns with given name" do
+        mig = RemoveProduceableFromProducts.new
+        mig.exec_migration(ActiveRecord::Base.connection, :up)
+        Product.reset_column_information
+        expect(Product.column_names).not_to include('produceable_id', 'produceable_type')
+      end
+    end
+
+    context "with no args" do
+      before do
+        initialize_database do
+          create_table(:products) do |t|
+            t.string :name
+            t.actable
+          end
+        end
+      end
+      it "creates polymorphic reference columns" do
+        mig = RemoveActableFromProducts.new
+        mig.exec_migration(ActiveRecord::Base.connection, :up)
+        Product.reset_column_information
+        expect(Product.column_names).not_to include('actable_id', 'actable_type')
       end
     end
   end


### PR DESCRIPTION
The `remove_actable` migration helper was using an invalid variable to reference the table name (perhaps it was renamed in a recent version of Rails?). I've updated it to be correct and added a spec for that migration helper as well.

See here for the variable in question inside the Rails codebase: https://github.com/rails/rails/blob/b165d73f2ccd421c9f3518ce9bf5bcb322440cb7/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L460

P.S. Big thanks for all your work on this gem, I'm using it in a medium-sized Rails project at the moment and it's been incredibly useful.