### PR TITLE
Few fixes to touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ end
 **Make sure** that column names do not match on parent and subclass tables,
 that will make SQL statements ambiguous and invalid!
 Specially **DO NOT** use timestamps on subclasses, if you need them define them
-on parent table and they will be touched after submodel updates.
+on parent table and they will be touched after submodel updates (You can use the option `touch: false` skip this behaviour).
 
 Now `Pen` and `Book` **acts as** `Product`, i.e. they inherit `Product`s **attributes**,
 **methods** and **validations**. Now you can do things like these:

--- a/lib/active_record/acts_as/instance_methods.rb
+++ b/lib/active_record/acts_as/instance_methods.rb
@@ -21,6 +21,7 @@ module ActiveRecord
       end
 
       def touch_actable
+        return unless changed?
         acting_as.touch
       end
 

--- a/lib/active_record/acts_as/relation.rb
+++ b/lib/active_record/acts_as/relation.rb
@@ -8,6 +8,7 @@ module ActiveRecord
         def acts_as(name, scope = nil, options = {})
           options, scope = scope, nil if Hash === scope
           association_method = options.delete(:association_method)
+          touch = options.delete(:touch)
           options = {as: :actable, dependent: :destroy, validate: false, autosave: true}.merge options
 
           cattr_reader(:validates_actable) { options.delete(:validates_actable) == false ? false : true }
@@ -24,7 +25,7 @@ module ActiveRecord
             end
           }
           validate :actable_must_be_valid
-          after_update :touch_actable
+          after_update :touch_actable unless touch == false
 
           cattr_reader(:acting_as_reflection) { reflections.stringify_keys[name.to_s] }
           cattr_reader(:acting_as_name) { name.to_s }

--- a/spec/acts_as_spec.rb
+++ b/spec/acts_as_spec.rb
@@ -223,6 +223,12 @@ RSpec.describe "ActiveRecord::Base model with #acts_as called" do
       expect(pen.updated_at).not_to eq(update)
     end
 
+    it "touches supermodel only when attributes changed" do
+      pen.save
+
+      expect { pen.save }.to_not change { pen.reload.product.updated_at }
+    end
+
     it "raises NoMethodEror on unexisting method call" do
       expect { pen.unexisted_method }.to raise_error(NoMethodError)
     end


### PR DESCRIPTION
1. provided an option to specify `touch: false`:
   In our case we have a topic super model, and we have something like `acts_as :topic`, but we only want topic to be touched when posts under topic are changed, not when the acts as model changed. Think it would be useful to skip touch.
2. Fixed an issue that super model is touched on every `save` on child, even child is not changed
