### PR TITLE
Upgrade to Rails 5

### DIFF
--- a/active_record-acts_as.gemspec
+++ b/active_record-acts_as.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake", "~> 10"
 
-  spec.add_dependency "activesupport", "~> 4"
-  spec.add_dependency "activerecord", "~> 4", ">= 4.1.2"
+  spec.add_dependency "activesupport", "~> 5"
+  spec.add_dependency "activerecord", "~> 5"
 end

--- a/active_record-acts_as.gemspec
+++ b/active_record-acts_as.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake", "~> 10"
 
-  spec.add_dependency "activesupport", "~> 5"
-  spec.add_dependency "activerecord", "~> 5"
+  spec.add_dependency "activesupport", ">= 4"
+  spec.add_dependency "activerecord", ">= 4.1.2"
 end

--- a/lib/active_record/acts_as/class_methods.rb
+++ b/lib/active_record/acts_as/class_methods.rb
@@ -1,13 +1,15 @@
 module ActiveRecord
   module ActsAs
+    module ReflectionsWithActsAs
+      def _reflections
+        @_reflections_acts_as_cache ||=
+          super.reverse_merge(acting_as_model._reflections)
+      end
+    end
+
     module ClassMethods
       def self.included(module_)
-        module_.alias_method_chain :_reflections, :acts_as
-      end
-
-      def _reflections_with_acts_as
-        @_reflections_acts_as_cache ||=
-          _reflections_without_acts_as.reverse_merge(acting_as_model._reflections)
+        module_.prepend ReflectionsWithActsAs
       end
 
       def validators_on(*args)

--- a/lib/active_record/acts_as/querying.rb
+++ b/lib/active_record/acts_as/querying.rb
@@ -3,6 +3,8 @@ module ActiveRecord
     module QueryMethods
       def where(opts = :chain, *rest)
         if acting_as? && opts.is_a?(Hash)
+          opts = opts.merge(opts.delete(klass.table_name) || {})
+
           opts, acts_as_opts = opts.stringify_keys.partition { |k,v| attribute_method?(k) }
           opts, acts_as_opts = Hash[opts], Hash[acts_as_opts]
           opts[acting_as_model.table_name] = acts_as_opts unless acts_as_opts.empty?

--- a/lib/active_record/acts_as/querying.rb
+++ b/lib/active_record/acts_as/querying.rb
@@ -1,25 +1,28 @@
-
 module ActiveRecord
-  module QueryMethods
-    def where_with_acts_as(opts = :chain, *rest)
-      if acting_as? && opts.is_a?(Hash)
-        opts, acts_as_opts = opts.stringify_keys.partition { |k,v| attribute_method?(k) }
-        opts, acts_as_opts = Hash[opts], Hash[acts_as_opts]
-        opts[acting_as_model.table_name] = acts_as_opts unless acts_as_opts.empty?
+  module ActsAs
+    module QueryMethods
+      def where(opts = :chain, *rest)
+        if acting_as? && opts.is_a?(Hash)
+          opts, acts_as_opts = opts.stringify_keys.partition { |k,v| attribute_method?(k) }
+          opts, acts_as_opts = Hash[opts], Hash[acts_as_opts]
+          opts[acting_as_model.table_name] = acts_as_opts unless acts_as_opts.empty?
+        end
+
+        super
       end
-      where_without_acts_as(opts, *rest)
     end
-    alias_method_chain :where, :acts_as
+
+    module ScopeForCreate
+      def scope_for_create
+        @scope_for_create ||= if acting_as?
+          where_values_hash.merge(where_values_hash(acting_as_model.table_name)).merge(create_with_value)
+        else
+          where_values_hash.merge(create_with_value)
+        end
+      end
+    end
   end
 
-  class Relation
-    def scope_for_create_with_acts_as
-      @scope_for_create ||= if acting_as?
-        where_values_hash.merge(where_values_hash(acting_as_model.table_name)).merge(create_with_value)
-      else
-        where_values_hash.merge(create_with_value)
-      end
-    end
-    alias_method_chain :scope_for_create, :acts_as
-  end
+  Relation.send(:prepend, ActsAs::QueryMethods)
+  Relation.send(:prepend, ActsAs::ScopeForCreate)
 end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -80,7 +80,7 @@ def initialize_schema
     create_table :inventory_product_features do |t|
       t.string :name
       t.float :price
-      t.actable
+      t.actable index: { name: 'index_inventory_product_features_on_actable' }
     end
   end
 end


### PR DESCRIPTION
Changed implementations of `alias_method_chain` to use `Module.prepend` instead, which according to [this](http://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/) is how it's done now.

The specs for Ruby versions less than < 2.2.2 fail, but Rails 5 requires Ruby 2.2.2 or newer.